### PR TITLE
Improve srcFile suffix replacement

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,9 +79,10 @@ Newer.prototype._transform = function(srcFile, encoding, done) {
   this._destStats.then(function(destStats) {
     if (destStats.isDirectory() || self._ext) {
       // stat dest/relative file
+      var relative = srcFile.relative;
       var destFileRelative = self._ext ?
-          srcFile.relative.replace(/\.([^\./].*?|)$/, self._ext) :
-          srcFile.relative;
+          relative.substr(0, relative.length - path.extname(relative).length) + self._ext :
+          relative;
       return Q.nfcall(fs.stat, path.join(self._dest, destFileRelative));
     } else {
       // wait to see if any are newer, then pass through all


### PR DESCRIPTION
When using gulp.src, if you set a base dir then you can end up with relative paths that start with a `../`.

The existing regex for replacing the file extension doesn't work in this case, even though the \* is non-greedy.

We also perhaps need to consider what a file extension is. Is it the last part of the filename, delimited by the `.` or is it everything from the first `.` in the filename (not dirname) part of the path?

I've assumed the later in this suggested change to the regex. It matches `.` followed by anything not another `.` or a `/`, and then any other characters to the end of the string. Or just `.` at the end of the string.
