### PR TITLE
Add options.suffix

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,10 @@ function Newer(options) {
     throw new PluginError('Requires ext to be a string');
   }
 
+  if (options.suffix && typeof options.suffix !== 'string') {
+    throw new PluginError('Requires suffix to be a string');
+  }
+
   /**
    * Path to destination directory or file.
    * @type {string}
@@ -36,6 +40,12 @@ function Newer(options) {
    * @type {string}
    */
   this._ext = options.ext;
+
+  /**
+   * Optional suffix for destination files.
+   * @type {string}
+   */
+  this._suffix = options.suffix;
 
   /**
    * Promise for the dest file/directory stats.
@@ -83,6 +93,9 @@ Newer.prototype._transform = function(srcFile, encoding, done) {
       var destFileRelative = self._ext ?
           relative.substr(0, relative.length - path.extname(relative).length) + self._ext :
           relative;
+      if (self._suffix) {
+        destFileRelative += self._suffix;
+      }
       return Q.nfcall(fs.stat, path.join(self._dest, destFileRelative));
     } else {
       // wait to see if any are newer, then pass through all

--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,7 @@ gulp.task('concat', function() {
 
  * **options.dest** - `string` As above, *required*.
  * **options.ext** - `string` Source files will be matched to destination files with the provided extension (e.g. '.css').
+ * **options.suffix** - `string` Source files will be matched to destination files with the suffix added (e.g. '.min').
 
 Create a [transform stream](http://nodejs.org/api/stream.html#stream_class_stream_transform_1) that passes through files whose modification time is more recent than the corresponding destination file's modification time.
 


### PR DESCRIPTION
I have a gulpflow where I want to check _newer_ against a file that I will append a suffix to. I can't predict the extension, so I think I need a `suffix` option. It's trivial to implement, of course! I've put together this little pull request. I hope you're keen to add it.

Best,
Karl
