### PR TITLE
Fixes exception swallowing.

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ Newer.prototype._transform = function(srcFile, encoding, done) {
       self.push(srcFile);
     }
     done();
-  }, done);
+  }).fail(done).end();
 
 };
 

--- a/spec.js
+++ b/spec.js
@@ -629,6 +629,33 @@ describe('newer()', function() {
 
       write(stream, paths);
     });
+  });
+
+  describe('reports errors', function() {
+    beforeEach(function() {
+      mock({
+        'q': mock.file({
+          mtime: new Date(100)
+        }),
+        dest: {}
+      });
+    });
+    afterEach(mock.restore);
+
+    it('in "data" handlers', function(done) {
+      var stream = newer('dest');
+
+      var err = new Error('test');
+
+      stream.on('data', function () { throw err; });
+
+      stream.on('error', function (caught) {
+        assert.equal(caught, err);
+        done();
+      });
+
+      write(stream, ['q']);
+    });
 
   });
 


### PR DESCRIPTION
Newer would swallow exceptions that occur in `data` event handlers. This commit fixes that problem.

Fixes #7.

For the record, I've also checked what happens when exceptions are raised in `end` and `error` handlers but these are turned into unhandled exceptions. Unfortunately Mocha does not allow easily testing that some code raises an unhandled exception so I've not produced tests for these.