### PR TITLE
Allow dest config to be omitted when map is provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function Newer(options) {
 
   if (typeof options === 'string') {
     options = {dest: options};
-  } else if (typeof options.dest !== 'undefined' && typeof options.dest !== 'string') {
+  } else if (options.dest && typeof options.dest !== 'string') {
     throw new PluginError(PLUGIN_NAME, 'Requires a dest string');
   }
 

--- a/spec.js
+++ b/spec.js
@@ -71,7 +71,6 @@ describe('newer()', function() {
   describe('config.map', function() {
 
     it('must be a function', function() {
-
       assert.throws(function() {
         newer({dest: 'foo', map: 1});
       });
@@ -80,6 +79,13 @@ describe('newer()', function() {
         newer({dest: 'foo', map: 'bar'});
       });
     });
+
+    it('makes the dest config optional', function() {
+      assert.doesNotThrow(function() {
+        newer({map: function() {}});
+      });
+    });
+
   });
 
   describe('dest dir that does not exist', function() {
@@ -628,6 +634,32 @@ describe('newer()', function() {
 
       write(stream, paths);
     });
+
+    it('allows people to join to dest themselves', function(done) {
+      var stream = newer({
+        map: function(destPath) {
+          return path.join('dest', destPath.replace('.ext1', '.ext2'));
+        }
+      });
+
+      var paths = ['file1.ext1', 'file2.ext1'];
+
+      var calls = 0;
+      stream.on('data', function(file) {
+        assert.equal(file.path, path.resolve('file2.ext1'));
+        ++calls;
+      });
+
+      stream.on('error', done);
+
+      stream.on('end', function() {
+        assert.equal(calls, 1);
+        done();
+      });
+
+      write(stream, paths);
+    });
+
   });
 
   describe('reports errors', function() {


### PR DESCRIPTION
This allows people to omit the `dest` config if they provide a `map` function.

This is a very slightly reworked version of the change proposed in #26 by @rogierschouten.

Fixes #25.