### PR TITLE
Add "extra" parameter to handle external dependencies.

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,14 @@ function Newer(options) {
     throw new PluginError(PLUGIN_NAME, 'Requires either options.dest or options.map or both');
   }
 
+  if (options.extra) {
+    if (typeof options.extra === 'string') {
+      options.extra = [options.extra];
+    } else if (!Array.isArray(options.extra)) {
+      throw new PluginError(PLUGIN_NAME, 'Requires options.extra to be a string or array');
+    }
+  }
+
   /**
    * Path to destination directory or file.
    * @type {string}
@@ -77,6 +85,42 @@ function Newer(options) {
    */
   this._all = false;
 
+  /**
+   * Indicates that there are extra files (configuration files, etc.)
+   * that are not to be fed into the stream, but that should force
+   * all files to be rebuilt if *any* are older than one of the extra
+   * files.
+   */
+  this._extraStats = null;
+
+  if (options.extra) {
+    var extraStats = [];
+    for (var i = 0; i < options.extra.length; ++i) {
+      extraStats.push(Q.nfcall(fs.stat, options.extra[i]));
+    }
+    this._extraStats = Q.all(extraStats)
+      .then(function(resolvedStats) {
+        // We get all the file stats here; find the *latest* modification.
+        var latestStat = resolvedStats[0];
+        for (var j = 1; j < resolvedStats.length; ++j) {
+          if (resolvedStats[j].mtime > latestStat.mtime) {
+            latestStat = resolvedStats[j];
+          }
+        }
+        return latestStat;
+      })
+      .fail(function(error) {
+        if (error && error.path) {
+          throw new PluginError(PLUGIN_NAME, 'Failed to read stats for an extra file: ' + error.path);
+        } else {
+          throw new PluginError(PLUGIN_NAME, 'Failed to stat extra files; unknown error: ' + error);
+        }
+      });
+
+    // When extra files are present, we buffer all the files.
+    this._bufferedFiles = [];
+  }
+
 }
 util.inherits(Newer, Transform);
 
@@ -93,57 +137,63 @@ Newer.prototype._transform = function(srcFile, encoding, done) {
     return;
   }
   var self = this;
-  this._destStats.then(function(destStats) {
-    if ((destStats && destStats.isDirectory()) || self._ext || self._map) {
-      // stat dest/relative file
-      var relative = srcFile.relative;
-      var ext = path.extname(relative);
-      var destFileRelative = self._ext ?
+  Q.resolve([this._destStats, this._extraStats])
+    .spread(function(destStats, extraStats) {
+      if ((destStats && destStats.isDirectory()) || self._ext || self._map) {
+        // stat dest/relative file
+        var relative = srcFile.relative;
+        var ext = path.extname(relative);
+        var destFileRelative = self._ext ?
           relative.substr(0, relative.length - ext.length) + self._ext :
           relative;
-      if (self._map) {
-        destFileRelative = self._map(destFileRelative);
-      }
-      var destFileJoined = self._dest ?
+        if (self._map) {
+          destFileRelative = self._map(destFileRelative);
+        }
+        var destFileJoined = self._dest ?
           path.join(self._dest, destFileRelative) : destFileRelative;
-      return Q.nfcall(fs.stat, destFileJoined);
-    } else {
-      // wait to see if any are newer, then pass through all
-      if (!self._bufferedFiles) {
-        self._bufferedFiles = [];
+        return Q.all([Q.nfcall(fs.stat, destFileJoined),extraStats]);
+      } else {
+        // wait to see if any are newer, then pass through all
+        if (!self._bufferedFiles) {
+          self._bufferedFiles = [];
+        }
+        return [destStats, extraStats];
       }
-      return Q.resolve(destStats);
-    }
-  }).fail(function(err) {
-    if (err.code === 'ENOENT') {
-      // dest file or directory doesn't exist, pass through all
-      return Q.resolve(null);
-    } else {
-      // unexpected error
-      return Q.reject(err);
-    }
-  }).then(function(destFileStats) {
-    var newer = !destFileStats || srcFile.stat.mtime > destFileStats.mtime;
-    if (self._all) {
-      self.push(srcFile);
-    } else if (!newer) {
-      if (self._bufferedFiles) {
-        self._bufferedFiles.push(srcFile);
+    }).fail(function(err) {
+      if (err.code === 'ENOENT') {
+        // dest file or directory doesn't exist, pass through all
+        return Q.resolve([null,this._extraStats]);
+      } else {
+        // unexpected error
+        return Q.reject(err);
       }
-    } else {
-      if (self._bufferedFiles) {
-        // flush buffer
-        self._bufferedFiles.forEach(function(file) {
-          self.push(file);
-        });
-        self._bufferedFiles.length = 0;
-        // pass through all remaining files as well
-        self._all = true;
+    }).spread(function(destFileStats, extraFileStats) {
+      var newer = !destFileStats || srcFile.stat.mtime > destFileStats.mtime;
+      // If *any* extra file is newer than a destination file, then ALL
+      // are newer.
+      if (extraFileStats && extraFileStats.mtime > destFileStats.mtime) {
+        newer = true;
       }
-      self.push(srcFile);
-    }
-    done();
-  }).fail(done).end();
+      if (self._all) {
+        self.push(srcFile);
+      } else if (!newer) {
+        if (self._bufferedFiles) {
+          self._bufferedFiles.push(srcFile);
+        }
+      } else {
+        if (self._bufferedFiles) {
+          // flush buffer
+          self._bufferedFiles.forEach(function(file) {
+            self.push(file);
+          });
+          self._bufferedFiles.length = 0;
+          // pass through all remaining files as well
+          self._all = true;
+        }
+        self.push(srcFile);
+      }
+      done();
+    }).fail(done).end();
 
 };
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "mock-fs": "^3.4.0"
   },
   "dependencies": {
-    "kew": "^0.7.0",
-    "gulp-util": "^3.0.7"
+    "glob": "^7.0.3",
+    "gulp-util": "^3.0.7",
+    "kew": "^0.7.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,7 @@ gulp.task('concat', function() {
  * **options.dest** - `string` As above, *required*.
  * **options.ext** - `string` Source files will be matched to destination files with the provided extension (e.g. '.css').
  * **options.map** - `function` Map relative source paths to relative destination paths (e.g. `function(relativePath) { return relativePath + '.bak'; }`)
+ * **options.extra** - `string` or `array` An extra file, or list of extra files, to check for updated time stamp(s). If any of these files are changed, then all files will be passed into the stream.
 
 Create a [transform stream](http://nodejs.org/api/stream.html#stream_class_stream_transform_1) that passes through files whose modification time is more recent than the corresponding destination file's modification time.
 

--- a/readme.md
+++ b/readme.md
@@ -70,7 +70,7 @@ gulp.task('concat', function() {
  * **options.dest** - `string` As above, *required*.
  * **options.ext** - `string` Source files will be matched to destination files with the provided extension (e.g. '.css').
  * **options.map** - `function` Map relative source paths to relative destination paths (e.g. `function(relativePath) { return relativePath + '.bak'; }`)
- * **options.extra** - `string` or `array` An extra file, or list of extra files, to check for updated time stamp(s). If any of these files are changed, then all files will be passed into the stream.
+ * **options.extra** - `string` or `array` An extra file, file glob, or list of extra files and/or globs, to check for updated time stamp(s). If any of these files are newer than the destination files, then all source files will be passed into the stream.
 
 Create a [transform stream](http://nodejs.org/api/stream.html#stream_class_stream_transform_1) that passes through files whose modification time is more recent than the corresponding destination file's modification time.
 


### PR DESCRIPTION
I added an "extra" parameter to options that will take a string or an array of strings that each refer to a filename. These files are configuration files related to the stream we're processing, but they are not themselves part of the stream; any change in the configuration files will cause *all* of the files to be rebuilt.

You can, for instance, add './gulpfile.js' to extra for a particular task, causing all files in that task to be rebuilt when gulpfile.js is touched. Alternately, if your transpiler configuration file is changed, gulp-newer can transpile all source files (if you make the transpiler configuration file an "extra" dependency).

I tested both 1-to-1 and 1-to-many cases, and I made sure that the current tests all pass. I didn't add new tests for this; I'm not really familiar with mocha, and I need to get back to my main project. Hoping this isn't a deal killer.