### PR TITLE
Update eslint, remove unused jshint dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,9 @@
   },
   "devDependencies": {
     "chai": "^3.4.0",
-    "eslint": "^1.7.3",
-    "eslint-config-tschaub": "^2.0.0",
+    "eslint": "^2.11.1",
+    "eslint-config-tschaub": "^4.0.0",
     "gulp": "^3.9.0",
-    "jshint": "~2.5.10",
     "mocha": "^2.3.3",
     "mock-fs": "^3.4.0"
   },


### PR DESCRIPTION
Doesn't look like `jshint` was used anywhere, was probably replaced by `eslint` sometime and wasn't removed