### PR TITLE
Resolved #41 and bumped patch version

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,9 +130,6 @@ function Newer(options) {
           throw new PluginError(PLUGIN_NAME, 'Failed to stat extra files; unknown error: ' + error);
         }
       });
-
-    // When extra files are present, we buffer all the files.
-    this._bufferedFiles = [];
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,18 @@
 {
   "name": "gulp-newer",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Only pass through newer source files",
   "homepage": "https://github.com/tschaub/gulp-newer",
   "author": {
     "name": "Tim Schaub",
     "url": "http://tschaub.net/"
   },
+  "contributors": [
+    {
+      "name": "Andrew Odri",
+      "url": "https://affirmix.com/"
+    }
+  ],
   "keywords": [
     "gulp",
     "gulpplugin",


### PR DESCRIPTION
It seems issue #41 was caused by **all** files being buffered on the existence of `options.extra`, which was overriding the logic in `Newer.prototype._transform`.

The version in `package.json` was bumped from 1.2.0 to 1.2.1.

The patch allows `options.extra` to function as expected. All tests are passing. Feel free to chop out the contribution in `package.json` if you don't like it as well.

If the npm package could be updated with this ASAP, that would be fantastic.