### PR TITLE
Feature: dependency map

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ function Newer(options) {
           // Ignore missing files, deps might have changed.
         });
     }
-    this._dependencyMapStats = Q.all(Object.values(depMapStats))
+    this._dependencyMapStats = Q.all(Object.keys(depMapStats).map(k => depMapStats[k]))
       // Resolve to depMapStats' promises' data.
       .then(_ => depMapStats)
       .then(promiseMap => {

--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,7 @@ gulp.task('concat', function() {
  * **options.ext** - `string` Source files will be matched to destination files with the provided extension (e.g. '.css').
  * **options.map** - `function` Map relative source paths to relative destination paths (e.g. `function(relativePath) { return relativePath + '.bak'; }`)
  * **options.extra** - `string` or `array` An extra file, file glob, or list of extra files and/or globs, to check for updated time stamp(s). If any of these files are newer than the destination files, then all source files will be passed into the stream.
+ * **options.dependencyMap** - `object` A map of source paths to an `array` of file paths of their dependencies.  These files will be checked for updated time stamp(s). If any of these dependency files are newer than the destination files, then all source files will be passed into the stream.  For example, this can be used with source maps of CSS builds where many input files map to many output files.
 
 Create a [transform stream](http://nodejs.org/api/stream.html#stream_class_stream_transform_1) that passes through files whose modification time is more recent than the corresponding destination file's modification time.
 


### PR DESCRIPTION
This feature allows to specify extra dependencies of files, much like the `extra` option, but instead of a single array (or string or glob), which is mostly useful when generating only a single output file, the map feature allows a gulp task to rebuild only the necessary files even in a many:many situation.

```js
const depMap = {
  "/some/place/a.scss": [
    "/some/place/else/b.scss",
    "/some/place/else/c.scss"
  ],
  "/some/place/d.scss": [
    "/some/place/else/b.scss"
  ],
  "/some/place/e.scss": [
    "/some/place/a.scss"
  ]
};
gulp.task('build:styles', function() {
  return gulp.src('/some/place/*.scss')
      .pipe(newer({
        dest: "dist",
        dependencyMap: depMap
      }))
      .pipe(sass())
      .pipe(gulp.dest('dist'));
});
```
