### PR TITLE
Drop deprecated dependency `gulp-util`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /node_modules/
+package-lock.json
+yarn.lock

--- a/index.js
+++ b/index.js
@@ -5,9 +5,7 @@ var util = require('util');
 var glob = require('glob');
 
 var Q = require('kew');
-var gutil = require('gulp-util');
-
-var PluginError = gutil.PluginError;
+var PluginError = require('plugin-error');
 
 var PLUGIN_NAME = 'gulp-newer';
 

--- a/package.json
+++ b/package.json
@@ -32,12 +32,13 @@
     "eslint-config-tschaub": "^6.0.0",
     "gulp": "^3.9.1",
     "mocha": "^3.1.0",
-    "mock-fs": "^4.0.0"
+    "mock-fs": "^4.0.0",
+    "vinyl": "^2.1.0"
   },
   "dependencies": {
     "glob": "^7.0.3",
-    "gulp-util": "^3.0.7",
-    "kew": "^0.7.0"
+    "kew": "^0.7.0",
+    "plugin-error": "^0.1.2"
   },
   "eslintConfig": {
     "extends": "tschaub"

--- a/spec.js
+++ b/spec.js
@@ -5,14 +5,13 @@ var fs = require('fs');
 var path = require('path');
 
 var chai = require('chai');
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 var mock = require('mock-fs');
 
 var newer = require('./index.js');
 
 chai.config.includeStack = true;
 
-var File = gutil.File;
 var assert = chai.assert;
 
 /**
@@ -23,7 +22,7 @@ var assert = chai.assert;
  */
 function write(stream, paths) {
   paths.forEach(function(filePath) {
-    stream.write(new File({
+    stream.write(new Vinyl({
       contents: fs.readFileSync(filePath),
       path: path.resolve(filePath),
       stat: fs.statSync(filePath)


### PR DESCRIPTION
Closes tschaub/gulp-newer#59