### PR TITLE
Scorpiocoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /node_modules/
+
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -1,3 +1,7 @@
+//2018-01-02 sc mod: gulp-util deprecation
+//2018-01-02 sc mod: require plugin-error to replace gutil.PluginError
+
+
 var Transform = require('stream').Transform;
 var fs = require('fs');
 var path = require('path');
@@ -5,9 +9,11 @@ var util = require('util');
 var glob = require('glob');
 
 var Q = require('kew');
-var gutil = require('gulp-util');
 
-var PluginError = gutil.PluginError;
+//var gutil = require('gulp-util');
+//var PluginError = gutil.PluginError;
+var PluginError = require('plugin-error');
+
 
 var PLUGIN_NAME = 'gulp-newer';
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   },
   "dependencies": {
     "glob": "^7.0.3",
-    "gulp-util": "^3.0.7",
     "kew": "^0.7.0",
     "plugin-error": "^0.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   "dependencies": {
     "glob": "^7.0.3",
     "gulp-util": "^3.0.7",
-    "kew": "^0.7.0"
+    "kew": "^0.7.0",
+    "plugin-error": "^0.1.2"
   },
   "eslintConfig": {
     "extends": "tschaub"


### PR DESCRIPTION
Hi there,

Created a hotfix for the gulp-util deprecation issue
Installed dependecies

    plugin-error as replacement for gulp-util.PluginError

files modified are:
.gitignore
--- added package-lock.json that occures when using VS code and SourceTree Git manager
package.json
--- added dependencies
index.js
--- mod code

I hope that my first try is a succes?
my firdst pull-request....lol

kind regards
scorpiocoding - kribo