### PR TITLE
added ctime option w/ tests, docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,11 +71,14 @@ gulp.task('concat', function() {
  * **options.ext** - `string` Source files will be matched to destination files with the provided extension (e.g. '.css').
  * **options.map** - `function` Map relative source paths to relative destination paths (e.g. `function(relativePath) { return relativePath + '.bak'; }`)
  * **options.extra** - `string` or `array` An extra file, file glob, or list of extra files and/or globs, to check for updated time stamp(s). If any of these files are newer than the destination files, then all source files will be passed into the stream.
+ * **options.ctime** - `boolean` Source files will be matched to destination files based on `ctime` rather than `mtime`.
 
 Create a [transform stream](http://nodejs.org/api/stream.html#stream_class_stream_transform_1) that passes through files whose modification time is more recent than the corresponding destination file's modification time.
 
 If `dest` is a directory path, the `newer` stream will check for files in the destination directory with the same relative path as source files.  Source files that have been modified more recently than the resolved destination file will be passed through.  If the `dest` directory or resolved destination file does not exist, all source files will be passed through.
 
 If `dest` is a file path, the `newer` stream will pass through *all* files if *any one* of them has been modified more recently than the destination file.  If the `dest` file does not exist, all source files will be passed through.
+
+By default, the `newer` stream will check files' *modification time*, or `mtime`, which updates when the file contents are changed. If `ctime` is `true`, files' *change time* will be checked instead, which updates when file contents or attributes like the file name or permissions have changed.
 
 [![Current Status](https://secure.travis-ci.org/tschaub/gulp-newer.png?branch=master)](https://travis-ci.org/tschaub/gulp-newer)

--- a/spec.js
+++ b/spec.js
@@ -265,7 +265,8 @@ describe('newer()', function() {
         dest: {
           file2: mock.file({
             content: 'file2 content',
-            mtime: new Date(1)
+            mtime: new Date(1),
+            ctime: new Date(1)
           })
         }
       });
@@ -292,6 +293,27 @@ describe('newer()', function() {
 
       write(stream, paths);
     });
+
+    it('passes through all files, checking ctime', function(done) {
+      var stream = newer({dest: 'dest', ctime: true});
+
+      var paths = ['file1', 'file2', 'file3'];
+
+      var calls = 0;
+      stream.on('data', function(file) {
+        assert.equal(file.path, path.resolve(paths[calls]));
+        ++calls;
+      });
+
+      stream.on('error', done);
+
+      stream.on('end', function() {
+        assert.equal(calls, paths.length);
+        done();
+      });
+
+      write(stream, paths);
+    });
   });
 
   describe('dest dir with one newer file', function() {
@@ -299,20 +321,24 @@ describe('newer()', function() {
       mock({
         file1: mock.file({
           content: 'file1 content',
-          mtime: new Date(100)
+          mtime: new Date(100),
+          ctime: new Date(100)
         }),
         file2: mock.file({
           content: 'file2 content',
-          mtime: new Date(100)
+          mtime: new Date(100),
+          ctime: new Date(100)
         }),
         file3: mock.file({
           content: 'file3 content',
-          mtime: new Date(100)
+          mtime: new Date(100),
+          ctime: new Date(100)
         }),
         dest: {
           file2: mock.file({
             content: 'file2 content',
-            mtime: new Date(200)
+            mtime: new Date(200),
+            ctime: new Date(200)
           })
         }
       });
@@ -339,6 +365,27 @@ describe('newer()', function() {
 
       write(stream, paths);
     });
+
+    it('passes through two newer files, checking ctime', function(done) {
+      var stream = newer({dest: 'dest', ctime: true});
+
+      var paths = ['file1', 'file2', 'file3'];
+
+      var calls = 0;
+      stream.on('data', function(file) {
+        assert.notEqual(file.path, path.resolve('file2'));
+        ++calls;
+      });
+
+      stream.on('error', done);
+
+      stream.on('end', function() {
+        assert.equal(calls, paths.length - 1);
+        done();
+      });
+
+      write(stream, paths);
+    });
   });
 
   describe('dest dir with two newer and one older file', function() {
@@ -346,28 +393,34 @@ describe('newer()', function() {
       mock({
         file1: mock.file({
           content: 'file1 content',
-          mtime: new Date(100)
+          mtime: new Date(100),
+          ctime: new Date(100)
         }),
         file2: mock.file({
           content: 'file2 content',
-          mtime: new Date(100)
+          mtime: new Date(100),
+          ctime: new Date(100)
         }),
         file3: mock.file({
           content: 'file3 content',
-          mtime: new Date(100)
+          mtime: new Date(100),
+          ctime: new Date(100)
         }),
         dest: {
           file1: mock.file({
             content: 'file1 content',
-            mtime: new Date(150)
+            mtime: new Date(150),
+            ctime: new Date(150)
           }),
           file2: mock.file({
             content: 'file2 content',
-            mtime: new Date(50)
+            mtime: new Date(50),
+            ctime: new Date(50)
           }),
           file3: mock.file({
             content: 'file3 content',
-            mtime: new Date(150)
+            mtime: new Date(150),
+            ctime: new Date(150)
           })
         }
       });
@@ -394,6 +447,27 @@ describe('newer()', function() {
 
       write(stream, paths);
     });
+
+    it('passes through one newer file, checking ctime', function(done) {
+      var stream = newer({dest: 'dest', ctime: true});
+
+      var paths = ['file1', 'file2', 'file3'];
+
+      var calls = 0;
+      stream.on('data', function(file) {
+        assert.equal(file.path, path.resolve('file2'));
+        ++calls;
+      });
+
+      stream.on('error', done);
+
+      stream.on('end', function() {
+        assert.equal(calls, 1);
+        done();
+      });
+
+      write(stream, paths);
+    });
   });
 
   describe('dest file with first source file newer', function() {
@@ -401,20 +475,24 @@ describe('newer()', function() {
       mock({
         file1: mock.file({
           content: 'file1 content',
-          mtime: new Date(200)
+          mtime: new Date(200),
+          ctime: new Date(200)
         }),
         file2: mock.file({
           content: 'file2 content',
-          mtime: new Date(100)
+          mtime: new Date(100),
+          ctime: new Date(100)
         }),
         file3: mock.file({
           content: 'file3 content',
-          mtime: new Date(100)
+          mtime: new Date(100),
+          ctime: new Date(100)
         }),
         dest: {
           output: mock.file({
             content: 'file2 content',
-            mtime: new Date(150)
+            mtime: new Date(150),
+            ctime: new Date(150)
           })
         }
       });
@@ -423,6 +501,27 @@ describe('newer()', function() {
 
     it('passes through all source files', function(done) {
       var stream = newer('dest/output');
+
+      var paths = ['file1', 'file2', 'file3'];
+
+      var calls = 0;
+      stream.on('data', function(file) {
+        assert.equal(file.path, path.resolve(paths[calls]));
+        ++calls;
+      });
+
+      stream.on('error', done);
+
+      stream.on('end', function() {
+        assert.equal(calls, paths.length);
+        done();
+      });
+
+      write(stream, paths);
+    });
+
+    it('passes through all source files, checking ctime', function(done) {
+      var stream = newer({dest: 'dest/output', ctime: true});
 
       var paths = ['file1', 'file2', 'file3'];
 
@@ -448,20 +547,24 @@ describe('newer()', function() {
       mock({
         file1: mock.file({
           content: 'file1 content',
-          mtime: new Date(100)
+          mtime: new Date(100),
+          ctime: new Date(100)
         }),
         file2: mock.file({
           content: 'file2 content',
-          mtime: new Date(200)
+          mtime: new Date(200),
+          ctime: new Date(200)
         }),
         file3: mock.file({
           content: 'file3 content',
-          mtime: new Date(100)
+          mtime: new Date(100),
+          ctime: new Date(100)
         }),
         dest: {
           output: mock.file({
             content: 'file2 content',
-            mtime: new Date(150)
+            mtime: new Date(150),
+            ctime: new Date(150)
           })
         }
       });
@@ -470,6 +573,27 @@ describe('newer()', function() {
 
     it('passes through all source files', function(done) {
       var stream = newer('dest/output');
+
+      var paths = ['file1', 'file2', 'file3'];
+
+      var calls = 0;
+      stream.on('data', function(file) {
+        assert.equal(file.path, path.resolve(paths[calls]));
+        ++calls;
+      });
+
+      stream.on('error', done);
+
+      stream.on('end', function() {
+        assert.equal(calls, paths.length);
+        done();
+      });
+
+      write(stream, paths);
+    });
+
+    it('passes through all source files, checking ctime', function(done) {
+      var stream = newer({dest: 'dest/output', ctime: true});
 
       var paths = ['file1', 'file2', 'file3'];
 
@@ -495,20 +619,24 @@ describe('newer()', function() {
       mock({
         file1: mock.file({
           content: 'file1 content',
-          mtime: new Date(100)
+          mtime: new Date(100),
+          ctime: new Date(100)
         }),
         file2: mock.file({
           content: 'file2 content',
-          mtime: new Date(100)
+          mtime: new Date(100),
+          ctime: new Date(100)
         }),
         file3: mock.file({
           content: 'file3 content',
-          mtime: new Date(200)
+          mtime: new Date(200),
+          ctime: new Date(200)
         }),
         dest: {
           output: mock.file({
             content: 'file2 content',
-            mtime: new Date(150)
+            mtime: new Date(150),
+            ctime: new Date(150)
           })
         }
       });
@@ -535,6 +663,27 @@ describe('newer()', function() {
 
       write(stream, paths);
     });
+
+    it('passes through all source files, checking ctime', function(done) {
+      var stream = newer({dest: 'dest/output', ctime: true});
+
+      var paths = ['file1', 'file2', 'file3'];
+
+      var calls = 0;
+      stream.on('data', function(file) {
+        assert.equal(file.path, path.resolve(paths[calls]));
+        ++calls;
+      });
+
+      stream.on('error', done);
+
+      stream.on('end', function() {
+        assert.equal(calls, paths.length);
+        done();
+      });
+
+      write(stream, paths);
+    });
   });
 
   describe('dest file with no newer source files', function() {
@@ -542,20 +691,24 @@ describe('newer()', function() {
       mock({
         file1: mock.file({
           content: 'file1 content',
-          mtime: new Date(100)
+          mtime: new Date(100),
+          ctime: new Date(100)
         }),
         file2: mock.file({
           content: 'file2 content',
-          mtime: new Date(100)
+          mtime: new Date(100),
+          ctime: new Date(100)
         }),
         file3: mock.file({
           content: 'file3 content',
-          mtime: new Date(100)
+          mtime: new Date(100),
+          ctime: new Date(100)
         }),
         dest: {
           output: mock.file({
             content: 'file2 content',
-            mtime: new Date(150)
+            mtime: new Date(150),
+            ctime: new Date(150)
           })
         }
       });
@@ -582,6 +735,27 @@ describe('newer()', function() {
 
       write(stream, paths);
     });
+
+    it('passes through no source files, checking ctime', function(done) {
+      var stream = newer({dest: 'dest/output', ctime: true});
+
+      var paths = ['file1', 'file2', 'file3'];
+
+      var calls = 0;
+      stream.on('data', function() {
+        done(new Error('Expected no source files'));
+        ++calls;
+      });
+
+      stream.on('error', done);
+
+      stream.on('end', function() {
+        assert.equal(calls, 0);
+        done();
+      });
+
+      write(stream, paths);
+    });
   });
 
   describe('dest file ext and two files', function() {
@@ -589,20 +763,24 @@ describe('newer()', function() {
       mock({
         'file1.ext1': mock.file({
           content: 'file1 content',
-          mtime: new Date(100)
+          mtime: new Date(100),
+          ctime: new Date(100)
         }),
         'file2.ext1': mock.file({
           content: 'file2 content',
-          mtime: new Date(100)
+          mtime: new Date(100),
+          ctime: new Date(100)
         }),
         dest: {
           'file1.ext2': mock.file({
             content: 'file1 content',
-            mtime: new Date(100)
+            mtime: new Date(100),
+            ctime: new Date(100)
           }),
           'file2.ext2': mock.file({
             content: 'file2 content',
-            mtime: new Date(50)
+            mtime: new Date(50),
+            ctime: new Date(50)
           })
         }
       });
@@ -629,6 +807,27 @@ describe('newer()', function() {
 
       write(stream, paths);
     });
+
+    it('passes through one newer file, checking ctime', function(done) {
+      var stream = newer({dest: 'dest', ext: '.ext2', ctime: true});
+
+      var paths = ['file1.ext1', 'file2.ext1'];
+
+      var calls = 0;
+      stream.on('data', function(file) {
+        assert.equal(file.path, path.resolve('file2.ext1'));
+        ++calls;
+      });
+
+      stream.on('error', done);
+
+      stream.on('end', function() {
+        assert.equal(calls, 1);
+        done();
+      });
+
+      write(stream, paths);
+    });
   });
 
   describe('custom mapping between source and dest', function() {
@@ -636,20 +835,24 @@ describe('newer()', function() {
       mock({
         'file1.ext1': mock.file({
           content: 'file1 content',
-          mtime: new Date(100)
+          mtime: new Date(100),
+          ctime: new Date(100)
         }),
         'file2.ext1': mock.file({
           content: 'file2 content',
-          mtime: new Date(100)
+          mtime: new Date(100),
+          ctime: new Date(100)
         }),
         dest: {
           'file1.ext2': mock.file({
             content: 'file1 content',
-            mtime: new Date(100)
+            mtime: new Date(100),
+            ctime: new Date(100)
           }),
           'file2.ext2': mock.file({
             content: 'file2 content',
-            mtime: new Date(50)
+            mtime: new Date(50),
+            ctime: new Date(50)
           })
         }
       });
@@ -662,6 +865,33 @@ describe('newer()', function() {
         map: function(destPath) {
           return destPath.replace('.ext1', '.ext2');
         }
+      });
+
+      var paths = ['file1.ext1', 'file2.ext1'];
+
+      var calls = 0;
+      stream.on('data', function(file) {
+        assert.equal(file.path, path.resolve('file2.ext1'));
+        ++calls;
+      });
+
+      stream.on('error', done);
+
+      stream.on('end', function() {
+        assert.equal(calls, 1);
+        done();
+      });
+
+      write(stream, paths);
+    });
+
+    it('passes through one newer file, checking ctime', function(done) {
+      var stream = newer({
+        dest: 'dest',
+        map: function(destPath) {
+          return destPath.replace('.ext1', '.ext2');
+        },
+        ctime: true
       });
 
       var paths = ['file1.ext1', 'file2.ext1'];


### PR DESCRIPTION
Hi hi! I have an oddly-specific use case that takes into account source files' naming conventions, and I realized and they weren't being caught by `gulp-newer` because it checks `mtimes`. I figured this use case is pretty rare, but having a `ctime` option might be useful to other people.

Added the `ctime` option with docs, and duplicated a bunch of the tests (there might be a better way to go about that, please let me know) to make sure all of the existing functionality works with both `mtime` and `ctime` checking.